### PR TITLE
Fix table display in README.md

### DIFF
--- a/actor-led-7segment-4numbers/README.md
+++ b/actor-led-7segment-4numbers/README.md
@@ -1,12 +1,13 @@
 tm1637.py is a driver library; display.py, displayIP.py, and clock.py all show its use
 
 ###Pins connection
-| Board Pin | Name | Remarks     | RPi Pin | RPi Function      |
-|----------:|:-----|:------------|--------:|-------------------|
-| 1         | GND  | Ground      | 2       | 5V0               |
-| 2         | VCC  | +5V Power   | 6       | GND               |
-| 3         | DIN  | Data In     | 38      | GPIO 20           |
-| 4         | CLK  | Clock       | 40      | GPIO 21           |
+
+    | Board Pin | Name | Remarks     | RPi Pin | RPi Function      |
+    |----------:|:-----|:------------|--------:|-------------------|
+    | 1         | GND  | Ground      | 2       | 5V0               |
+    | 2         | VCC  | +5V Power   | 6       | GND               |
+    | 3         | DIN  | Data In     | 38      | GPIO 20           |
+    | 4         | CLK  | Clock       | 40      | GPIO 21           |
 
 ![image of device](pic1.JPG)
 


### PR DESCRIPTION
This renders the connection table as pre-formatted text so that it renders properly when viewed on github.